### PR TITLE
Rebuild home page with themes and project modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,109 +1,195 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Khushi Juneja</title>
-  <!-- Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Playfair+Display:wght@700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
 </head>
-<body>
-  <!-- Top Navigation Bar -->
-  <header class="site-header">
-    <nav class="nav-bar">
-      <a class="logo" href="index.html">Khushi Juneja</a>
-      <button class="nav-toggle" aria-label="open navigation">☰</button>
-      <ul class="nav-links">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="playground.html">Playground</a></li>
-        <li><a href="notes.html">Notes</a></li>
-      </ul>
-    </nav>
-    <button id="vibe-toggle" class="vibe-toggle" aria-label="toggle vibe">✨</button>
+<body class="theme-default">
+  <button id="vibe-toggle" class="vibe-toggle" aria-label="toggle vibe">✨ toggle vibe</button>
+
+  <header class="intro">
+    <h1>hey, i’m khushi.</h1>
+    <p class="devanagari">ख़ुशी (khushi) — Hindi: happiness</p>
+    <p class="intro-line">Products, puzzles, and playful systems—built with research, rigor, and a little mischief.</p>
+    <p id="title-rotator" class="rotating-title" aria-live="polite"></p>
   </header>
 
-  <!-- Welcome Section -->
-  <section class="welcome">
-    <h1>Hey, I’m Khushi.</h1>
-    <p class="tagline">I build, write, and play with systems—whether in code, cardboard, or conversation.</p>
-    <p class="rotating-subtitle" id="subtitle">Forever prototyping.</p>
-  </section>
+  <main>
+    <section class="substack" aria-labelledby="substack-label">
+      <h2 id="substack-label" class="visually-hidden">Substack</h2>
+      <div id="substack-cards" class="substack-cards"></div>
+    </section>
 
-  <!-- In the Spotlight -->
-  <section class="spotlight">
-    <h2>In the Spotlight</h2>
-    <div class="projects">
-      <article class="project-card" id="odd-toys">
-        <h3>Odd Toys <span>🧩</span></h3>
-        <p>Playful tools for curious minds.</p>
-        <a class="project-link" href="playground.html#odd-toys">Explore →</a>
-      </article>
-      <article class="project-card" id="learning-lab">
-        <h3>Learning Lab <span>🔬</span></h3>
-        <p>Experiments in education design.</p>
-        <a class="project-link" href="playground.html#learning-lab">Explore →</a>
-      </article>
-      <article class="project-card" id="side-quests">
-        <h3>Side Quests <span>🎮</span></h3>
-        <p>Tiny games with big feelings.</p>
-        <a class="project-link" href="playground.html#side-quests">Explore →</a>
-      </article>
-    </div>
-  </section>
+    <section class="projects-section" aria-labelledby="projects-label">
+      <h2 id="projects-label">projects</h2>
+      <div class="projects-grid">
+        <button class="project-card" data-title="Project One">
+          <span class="project-title">Project One</span>
+          <span class="project-open">Click to open</span>
+        </button>
+        <button class="project-card" data-title="Project Two">
+          <span class="project-title">Project Two</span>
+          <span class="project-open">Click to open</span>
+        </button>
+        <button class="project-card" data-title="Project Three">
+          <span class="project-title">Project Three</span>
+          <span class="project-open">Click to open</span>
+        </button>
+        <button class="project-card" data-title="Project Four">
+          <span class="project-title">Project Four</span>
+          <span class="project-open">Click to open</span>
+        </button>
+        <button class="project-card" data-title="Project Five">
+          <span class="project-title">Project Five</span>
+          <span class="project-open">Click to open</span>
+        </button>
+        <button class="project-card" data-title="Project Six">
+          <span class="project-title">Project Six</span>
+          <span class="project-open">Click to open</span>
+        </button>
+        <button class="project-card" data-title="Project Seven">
+          <span class="project-title">Project Seven</span>
+          <span class="project-open">Click to open</span>
+        </button>
+        <button class="project-card" data-title="Project Eight">
+          <span class="project-title">Project Eight</span>
+          <span class="project-open">Click to open</span>
+        </button>
+      </div>
+      <p class="view-more"><a href="playground.html">View more →</a></p>
+    </section>
 
-  <!-- Meet Me -->
-  <section class="meet-me">
-    <h2>Meet Me</h2>
-    <p>Hello! I’m Khushi, a playful systems thinker who believes in making messy ideas tangible. If it can be prototyped, I’ve probably tried it.</p>
-    <ul class="beliefs">
-      <li>Card games are sacred.</li>
-      <li>Curiosity &gt; credentials.</li>
-      <li>Everything is a prototype.</li>
-    </ul>
-    <div class="badges">
-      <span class="badge">🎲 Game Designer</span>
-      <span class="badge">🧠 EdTech Researcher</span>
-      <span class="badge">📨 Substack Writer</span>
-      <span class="badge">🔨 Tinkerer</span>
-    </div>
-  </section>
+    <section class="about" aria-labelledby="about-label">
+      <h2 id="about-label">about + contact</h2>
+      <p>I’m pursuing a B.S. in Mathematical Sciences &amp; Human-Computer Interaction at Carnegie Mellon University (Dean’s List), with a concentration in Operations Research &amp; Statistics and a minor in Design for Learning. Recently: Strategy &amp; Impact Intern at The Unifly Collective (edtech), Product Management Intern at Vinsol, Data Analysis RA at CMU’s OH! Lab, and Educational Game Dev Researcher at IIT Kanpur.</p>
+      <ul class="contact-list">
+        <li>Email: <a href="mailto:kjuneja@andrew.cmu.edu">kjuneja@andrew.cmu.edu</a></li>
+        <li>LinkedIn: <a href="https://www.linkedin.com/in/kj3010/">https://www.linkedin.com/in/kj3010/</a></li>
+      </ul>
+    </section>
+  </main>
 
-  <!-- Contact Me -->
-  <section class="contact">
-    <h2>Contact Me</h2>
-    <p>Thinking about a project? Or just vibing with the vibe? Say hi.</p>
-    <form class="contact-form">
-      <label>
-        Name
-        <input type="text" name="name" required>
-      </label>
-      <label>
-        Email
-        <input type="email" name="email" required>
-      </label>
-      <label>
-        Message
-        <textarea name="message" rows="4" required></textarea>
-      </label>
-      <button type="submit" title="Sending this might change your life.">Submit</button>
-    </form>
-  </section>
-
-  <!-- Footer -->
   <footer class="site-footer">
-    <div class="social">
-      <a href="mailto:placeholder@example.com">Email</a>
-      <a href="#">LinkedIn</a>
-      <a href="#">GitHub</a>
-    </div>
-    <p class="credits">Made with sticky notes, chai, and chaos.</p>
+    <p>Designed by Khushi. Debugged by instinct.</p>
   </footer>
 
-  <!-- You found one! There are 2 more... -->
+  <div id="project-modal" class="modal" aria-hidden="true">
+    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="project-modal-title">
+      <h3 id="project-modal-title"></h3>
+      <p>Content coming next iteration.</p>
+      <button class="modal-close" data-close>Close</button>
+    </div>
+  </div>
 
-  <script src="script.js"></script>
+  <script>
+    // Rotating titles
+    const titles = [
+      'creative technologist',
+      'product-minded researcher',
+      'learning experience designer',
+      'systems/studio thinker',
+      'data-curious builder',
+      'strategy + ops tinkerer',
+      'game-maker (analog + digital)',
+      'writer of notes and notebooks',
+      'prototype sprint runner',
+      'sometimes hardware, often html',
+      'metrics, but humane',
+      'always shipping, always revising'
+    ];
+    const rotator = document.getElementById('title-rotator');
+    let titleIndex = 0;
+    const prefersReduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    function showTitle() {
+      rotator.classList.remove('show');
+      rotator.textContent = titles[titleIndex];
+      requestAnimationFrame(() => rotator.classList.add('show'));
+      titleIndex = (titleIndex + 1) % titles.length;
+    }
+    let rotateInterval = setInterval(showTitle, 2700);
+    showTitle();
+    rotator.addEventListener('mouseover', () => clearInterval(rotateInterval));
+    rotator.addEventListener('mouseout', () => rotateInterval = setInterval(showTitle, 2700));
+    if (prefersReduce) {
+      rotator.classList.add('no-transition');
+    }
+
+    // Vibe toggle
+    const themes = ['theme-default','theme-studio','theme-night','theme-citrus'];
+    const vibeBtn = document.getElementById('vibe-toggle');
+    let currentTheme = localStorage.getItem('theme');
+    if (themes.includes(currentTheme)) {
+      document.body.className = currentTheme;
+    } else {
+      currentTheme = 'theme-default';
+    }
+    vibeBtn.addEventListener('click', () => {
+      let idx = themes.indexOf(currentTheme);
+      idx = (idx + 1) % themes.length;
+      currentTheme = themes[idx];
+      document.body.className = currentTheme;
+      localStorage.setItem('theme', currentTheme);
+    });
+
+    // Substack randomizer
+    const posts = [
+      { title: 'Notes — latest letter', teaser: 'On learning by doing.', url: '#' },
+      { title: 'Notes — a favorite', teaser: 'Play, presence, and practice.', url: '#' },
+      { title: 'Notes — studio log', teaser: 'Fragments from the cutting room floor.', url: '#' },
+      { title: 'Notes — product scraps', teaser: 'Feature bets, tradeoffs, and tests.', url: '#' },
+      { title: 'Notes — field notes', teaser: 'People, patterns, and prototypes.', url: '#' },
+      { title: 'Notes — thinking in public', teaser: 'Working notes, not finished essays.', url: '#' }
+    ];
+    const substackContainer = document.getElementById('substack-cards');
+    const chosen = [];
+    while (chosen.length < 2) {
+      const idx = Math.floor(Math.random() * posts.length);
+      if (!chosen.includes(idx)) chosen.push(idx);
+    }
+    chosen.forEach(i => {
+      const item = posts[i];
+      const card = document.createElement('article');
+      card.className = 'substack-card';
+      card.innerHTML = `<h3>${item.title}</h3><p>${item.teaser}</p><a href="${item.url}">Read on Substack →</a>`;
+      substackContainer.appendChild(card);
+    });
+
+    // Project modals
+    const modal = document.getElementById('project-modal');
+    const modalTitle = document.getElementById('project-modal-title');
+    document.querySelectorAll('.project-card').forEach(card => {
+      card.addEventListener('click', () => {
+        modalTitle.textContent = card.dataset.title;
+        modal.classList.add('open');
+        modal.setAttribute('aria-hidden', 'false');
+        document.body.classList.add('modal-open');
+        const closeBtn = modal.querySelector('.modal-close');
+        closeBtn.focus();
+        modal.addEventListener('keydown', trapFocus);
+      });
+    });
+    function closeModal() {
+      modal.classList.remove('open');
+      modal.setAttribute('aria-hidden', 'true');
+      document.body.classList.remove('modal-open');
+      modal.removeEventListener('keydown', trapFocus);
+    }
+    function trapFocus(e) {
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        modal.querySelector('.modal-close').focus();
+      } else if (e.key === 'Escape') {
+        closeModal();
+      }
+    }
+    modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
+    modal.querySelectorAll('[data-close]').forEach(btn => btn.addEventListener('click', closeModal));
+    document.addEventListener('keydown', e => { if (e.key === 'Escape' && modal.classList.contains('open')) closeModal(); });
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,274 +1,310 @@
-/* Global Styles */
-:root {
-  --bg: #f9f8f5;
-  --accent: #2643e9;
-  --text: #222;
-}
-
+/* Base styles */
 body {
   margin: 0;
-  font-family: 'Inter', 'Nunito', 'Open Sans', sans-serif;
+  font-family: 'Inter', system-ui, sans-serif;
+  line-height: 1.6;
   background: var(--bg);
   color: var(--text);
-  line-height: 1.6;
+  transition: background 0.3s, color 0.3s;
 }
 
 h1, h2, h3 {
   font-family: 'Playfair Display', 'JetBrains Mono', serif;
-  margin-bottom: 0.5rem;
+  line-height: 1.2;
 }
 
-/* Navigation */
-.site-header {
-  position: sticky;
-  top: 0;
-  background: var(--bg);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.5rem 1rem;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  z-index: 1000;
-}
-
-.logo {
-  font-weight: 600;
-  text-decoration: none;
-  color: var(--accent);
-}
-
-.nav-links {
-  list-style: none;
-  display: flex;
-  gap: 1rem;
-  margin: 0;
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
   padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
 }
 
-.nav-links a {
-  text-decoration: none;
-  color: inherit;
-  transition: color 0.3s;
+:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
-.nav-links a:hover {
-  color: var(--accent);
+/* Theme variables */
+body.theme-default {
+  --bg: #faf8f6;
+  --text: #111;
+  --accent: #2a4bff;
+  --accent-2: #7e2941;
+  --card-bg: #ffffff;
 }
 
-.nav-toggle {
-  display: none;
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
+body.theme-studio {
+  --bg: #1f1f2b;
+  --text: #ffffff;
+  --accent: #2a4bff;
+  --accent-2: #8aa0ff;
+  --card-bg: #2a2a3a;
 }
 
+body.theme-night {
+  --bg: #0a0a0f;
+  --text: #e8e8e8;
+  --accent: #39ff14;
+  --accent-2: #ff6ec7;
+  --card-bg: #18181e;
+}
+
+body.theme-citrus {
+  --bg: #fff9f0;
+  --text: #222;
+  --accent: #ffb400;
+  --accent-2: #008080;
+  --card-bg: #ffffff;
+}
+
+/* Vibe toggle */
 .vibe-toggle {
   position: fixed;
   top: 1rem;
   right: 1rem;
   background: var(--accent);
-  color: #fff;
+  color: var(--bg);
   border: none;
-  border-radius: 50%;
-  padding: 0.5rem 0.6rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 1rem;
   cursor: pointer;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  font-size: 0.9rem;
+  z-index: 1000;
 }
 
-/* Welcome Section */
-.welcome {
+/* Intro */
+.intro {
   text-align: center;
-  padding: 4rem 1rem;
+  padding: 5rem 1rem 3rem;
 }
 
-.welcome h1 {
+.intro h1 {
   font-size: 2.5rem;
+  margin-bottom: 0.25rem;
 }
 
-.rotating-subtitle {
+.devanagari {
+  font-size: 0.9rem;
+  margin-top: 0;
+  color: var(--accent-2);
+}
+
+.intro-line {
   font-weight: 600;
-  margin-top: 1rem;
-  color: var(--accent);
-  min-height: 1.5em;
+  max-width: 42rem;
+  margin: 1rem auto;
 }
 
-/* Spotlight Section */
-.spotlight {
+.rotating-title {
+  color: var(--accent);
+  font-weight: 600;
+  min-height: 1.5em;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+
+.rotating-title.show {
+  opacity: 1;
+}
+
+.rotating-title.no-transition {
+  transition: none;
+}
+
+/* Substack */
+.substack {
+  padding: 2rem 1rem;
+}
+
+.substack-cards {
+  display: grid;
+  gap: 1rem;
+  max-width: 900px;
+  margin: 0 auto;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 600px) {
+  .substack-cards {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.substack-card {
+  background: var(--card-bg);
+  padding: 1rem;
+  border-radius: 10px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+.substack-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.substack-card p {
+  margin: 0 0 0.5rem;
+}
+
+.substack-card a {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.substack-card a:hover {
+  text-decoration: underline;
+}
+
+/* Projects */
+.projects-section {
   padding: 2rem 1rem;
   max-width: 1000px;
   margin: 0 auto;
 }
 
-.projects {
+.projects-section h2 {
+  font-size: 1.1rem;
+  text-transform: lowercase;
+  margin-bottom: 1rem;
+  color: var(--accent-2);
+}
+
+.projects-grid {
   display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 }
 
 .project-card {
-  background: #fff;
-  padding: 1rem;
+  background: var(--card-bg);
+  border: none;
   border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-  transition: transform 0.3s, box-shadow 0.3s;
+  padding: 1.5rem 1rem;
+  text-align: left;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .project-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  transform: translateY(-4px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
 }
 
-.project-link {
-  display: inline-block;
-  margin-top: 0.5rem;
+.project-title {
+  font-weight: 600;
+}
+
+.project-open {
+  font-size: 0.9rem;
+  color: var(--accent);
+}
+
+.view-more {
+  text-align: right;
+  margin-top: 1rem;
+}
+
+.view-more a {
   color: var(--accent);
   text-decoration: none;
   font-weight: 600;
 }
 
-.project-link:hover {
+.view-more a:hover {
   text-decoration: underline;
 }
 
-/* Meet Me Section */
-.meet-me {
+/* About */
+.about {
   padding: 2rem 1rem;
-  max-width: 800px;
+  max-width: 900px;
   margin: 0 auto;
 }
 
-.beliefs {
+.about h2 {
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+}
+
+.contact-list {
   list-style: none;
-  display: grid;
-  gap: 0.5rem;
   padding: 0;
-  margin: 1rem 0;
-}
-
-.badges {
+  margin: 0;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 0.5rem;
 }
 
-.badge {
-  background: var(--accent);
-  color: #fff;
-  padding: 0.3rem 0.6rem;
-  border-radius: 20px;
-  font-size: 0.9rem;
+.contact-list a {
+  color: var(--accent);
+  text-decoration: none;
 }
 
-/* Contact Section */
-.contact {
-  padding: 2rem 1rem;
-  max-width: 600px;
-  margin: 0 auto;
-}
-
-.contact-form {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.contact-form label {
-  display: flex;
-  flex-direction: column;
-  font-weight: 600;
-}
-
-.contact-form input,
-.contact-form textarea {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-family: inherit;
-}
-
-.contact-form input:focus,
-.contact-form textarea:focus {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(38,67,233,0.2);
-}
-
-.contact-form button {
-  align-self: flex-start;
-  background: var(--accent);
-  color: #fff;
-  padding: 0.6rem 1.2rem;
-  border: none;
-  border-radius: 25px;
-  cursor: pointer;
-  transition: transform 0.3s, box-shadow 0.3s, background 0.3s;
-}
-
-.contact-form button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 10px rgba(0,0,0,0.2);
-  background: linear-gradient(135deg, var(--accent), #8ab3ff);
+.contact-list a:hover {
+  text-decoration: underline;
 }
 
 /* Footer */
 .site-footer {
   text-align: center;
   padding: 2rem 1rem;
-  background: #fff;
-  margin-top: 2rem;
+  font-size: 0.9rem;
 }
 
-.site-footer .social a {
-  margin: 0 0.5rem;
-  text-decoration: none;
-  color: var(--accent);
+/* Modals */
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1001;
 }
 
-.site-footer .social a:hover {
-  text-decoration: underline;
+.modal.open {
+  display: flex;
 }
 
-/* Section Animations */
-section {
-  opacity: 0;
-  transform: translateY(20px);
-  animation: fadeIn 0.8s forwards;
+.modal-content {
+  background: var(--card-bg);
+  color: var(--text);
+  padding: 2rem;
+  border-radius: 8px;
+  max-width: 90%;
+  width: 100%;
+  max-width: 680px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
 }
 
-section:nth-of-type(1) { animation-delay: 0.2s; }
-section:nth-of-type(2) { animation-delay: 0.4s; }
-section:nth-of-type(3) { animation-delay: 0.6s; }
-section:nth-of-type(4) { animation-delay: 0.8s; }
+.modal-close {
+  margin-top: 1rem;
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
 
-@keyframes fadeIn {
-  to {
-    opacity: 1;
-    transform: translateY(0);
+body.modal-open {
+  overflow: hidden;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition: none !important;
+  }
+  .project-card:hover {
+    transform: none;
   }
 }
-
-/* Responsive Navigation */
-@media (max-width: 600px) {
-  .nav-links {
-    display: none;
-    flex-direction: column;
-    position: absolute;
-    right: 1rem;
-    top: 3rem;
-    background: var(--bg);
-    padding: 1rem;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
-  }
-
-  .nav-links.show {
-    display: flex;
-  }
-
-  .nav-toggle {
-    display: block;
-  }
-}
-
-/* Hidden Easter Egg */
-/* Almost there! One more to find... */


### PR DESCRIPTION
## Summary
- Replace old multi-section layout with single-page home and bold intro.
- Add vibe toggle cycling among default, studio, night, and citrus themes with persistence.
- Randomize two Substack cards and showcase eight placeholder projects opening modals.
- Include quick bio, contact links, and accessible markup throughout.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0b2515e48322bd2de8be137289f9